### PR TITLE
MAINT: Release upper bound on NumPy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ajquinn
+* @ajquinn @larsoner

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,7 +24,10 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
@@ -45,6 +48,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About emd
-=========
+About emd-feedstock
+===================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/emd-feedstock/blob/main/LICENSE.txt)
 
 Home: https://pypi.org/project/emd/
 
 Package license: GPL-3.0-or-later
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/emd-feedstock/blob/main/LICENSE.txt)
 
 Summary: Empirical Mode Decomposition
 
@@ -150,4 +150,5 @@ Feedstock Maintainers
 =====================
 
 * [@ajquinn](https://github.com/ajquinn/)
+* [@larsoner](https://github.com/larsoner/)
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "emd" %}
-{% set version = "0.5.5" %}
+{% set version = "0.6.1" %}
 
 
 package:
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/emd-{{ version }}.tar.gz
-  sha256: f44a1871c72a0599f6197fef08de61cf3742ce49d134e505852c1a6b24d13966
+  sha256: c50ee966f45b6098dd6c704ad25caca33abd9879264318257a43407786f6289c
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "emd" %}
-{% set version = "0.6.1" %}
+{% set version = "0.6.2" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/emd-{{ version }}.tar.gz
-  sha256: c50ee966f45b6098dd6c704ad25caca33abd9879264318257a43407786f6289c
+  sha256: 38682f72adf7c406b7fc87316659fd159450b1dd946d48666deb893ef92c1fdc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: f44a1871c72a0599f6197fef08de61cf3742ce49d134e505852c1a6b24d13966
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -21,7 +21,7 @@ requirements:
     - python >=3.6
   run:
     - python >=3.6
-    - numpy <1.22,>=1.17
+    - numpy >=1.19.3
     - scipy
     - matplotlib-base
     - pandas
@@ -51,3 +51,4 @@ about:
 extra:
   recipe-maintainers:
     - ajquinn
+    - larsoner


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

A year ago I relaxed the upper bound on the NumPy version in https://github.com/conda-forge/emd-feedstock/pull/7 . This PR removes it completely as 1) it's going to keep causing problems and 2) it doesn't appear in upstream setup.py or requirements.txt, e.g.:

https://gitlab.com/emd-dev/emd/-/blob/master/requirements.txt#L2

Should fix this issue:

<details>
<summary>EMD not 3.11 compatible because of NumPy pin</summary>

```
Could not solve for environment specs
The following packages are incompatible
├─ emd 0.5.5**  is installable and it requires
│  └─ numpy <1.22,>=1.17  with the potential options
│     ├─ numpy [1.17.0|1.17.1|...|1.19.2] would require
│     │  └─ python >=3.6,<3.7.0a0  with the potential options
│     │     ├─ python [3.6.0|3.6.1|...|3.6.9], which can be installed;
│     │     ├─ python 3.6.3 would require
│     │     │  └─ zlib 1.2.8 , which can be installed;
│     │     └─ python [3.6.3|3.6.4|3.6.5] would require
│     │        └─ zlib 1.2.11 , which can be installed;
│     ├─ numpy [1.17.0|1.17.1|...|1.21.5] would require
│     │  └─ python >=3.7,<3.8.0a0 , which can be installed;
│     ├─ numpy [1.17.3|1.17.4|...|1.21.5] would require
│     │  └─ python >=3.8,<3.9.0a0 , which can be installed;
│     ├─ numpy [1.17.5|1.18.1|...|1.19.5] would require
│     │  ├─ python >=3.6,<3.7.0a0  with the potential options
│     │  │  ├─ python [3.6.0|3.6.1|...|3.6.9], which can be installed;
│     │  │  ├─ python 3.6.3, which can be installed (as previously explained);
│     │  │  └─ python [3.6.3|3.6.4|3.6.5], which can be installed (as previously explained);
│     │  └─ python_abi 3.6.* *_cp36m, which can be installed;
│     ├─ numpy [1.17.5|1.18.1|...|1.21.6] would require
│     │  ├─ python >=3.7,<3.8.0a0 , which can be installed;
│     │  └─ python_abi 3.7.* *_cp37m, which can be installed;
│     ├─ numpy [1.17.5|1.18.1|...|1.21.6] would require
│     │  ├─ python >=3.8,<3.9.0a0 , which can be installed;
│     │  └─ python_abi 3.8.* *_cp38, which can be installed;
│     ├─ numpy [1.18.1|1.18.4|...|1.19.5] would require
│     │  └─ python_abi 3.6 *_pypy36_pp73, which requires
│     │     └─ python 3.6.* *_73_pypy, which can be installed;
│     ├─ numpy [1.19.2|1.19.4|...|1.21.6] would require
│     │  ├─ python >=3.9,<3.10.0a0 , which can be installed;
│     │  └─ python_abi 3.9.* *_cp39, which can be installed;
│     ├─ numpy [1.19.5|1.20.0|...|1.21.5] would require
│     │  └─ python_abi 3.7 *_pypy37_pp73, which requires
│     │     └─ python 3.7.* *_73_pypy, which can be installed;
│     ├─ numpy [1.19.5|1.20.3|1.21.5|1.21.6] would require
│     │  └─ python_abi 3.8 *_pypy38_pp73, which can be installed;
│     ├─ numpy [1.19.5|1.20.3|1.21.5|1.21.6] would require
│     │  └─ python_abi 3.9 *_pypy39_pp73, which can be installed;
│     ├─ numpy [1.21.3|1.21.4|1.21.5|1.21.6] would require
│     │  ├─ python >=3.10,<3.11.0a0 , which can be installed;
│     │  └─ python_abi 3.10.* *_cp310, which can be installed;
│     ├─ numpy [1.19.2|1.19.5|...|1.21.5] would require
│     │  └─ python >=3.9,<3.10.0a0 , which can be installed;
│     └─ numpy [1.21.2|1.21.5] would require
│        └─ python >=3.10,<3.11.0a0 , which can be installed;
├─ mne 1.4dev0 *_20230503 is uninstallable because it requires
│  └─ openmeeg >=2.5.6 , which requires
│     └─ libzlib >=1.2.13,<1.3.0a0 , which requires
│        └─ zlib 1.2.13 *_4, which conflicts with any installable versions previously reported;
└─ python 3.11.3**  is uninstallable because it conflicts with any installable versions previously reported.
```

</details>

@AJQuinn I added myself as a maintainer since I do this sort of stuff for a lot of packages (mne-*, mayavi, etc.) but I can remove myself if you want.

Closes #9
Closes #10
Closes #11